### PR TITLE
Expose some helper methods to return the insertable columns

### DIFF
--- a/lib/bulk_insert.rb
+++ b/lib/bulk_insert.rb
@@ -5,7 +5,7 @@ module BulkInsert
 
   class_methods do
     def bulk_insert(*columns, set_size:500)
-      columns = self.column_names - %w(id) if columns.empty?
+      columns = default_bulk_columns if columns.empty?
       worker = BulkInsert::Worker.new(connection, table_name, columns, set_size)
 
       if block_given?
@@ -18,6 +18,12 @@ module BulkInsert
         worker
       end
     end
+
+    # helper method for preparing the columns before a call to :bulk_insert
+    def default_bulk_columns
+      self.column_names - %w(id)
+    end
+
   end
 end
 

--- a/test/bulk_insert_test.rb
+++ b/test/bulk_insert_test.rb
@@ -19,4 +19,11 @@ class BulkInsertTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "default_bulk_columns should return all columns without id" do
+    default_columns = %w(greeting age happy created_at updated_at)
+
+    assert_equal Testing.default_bulk_columns, default_columns
+  end
+
 end


### PR DESCRIPTION
The goal is to help developers to choose columns.

The following example uses the Testing model available in the `spec` directory:

```ruby
blacklisted_columns = %(age ...)
columns = Testing.default_bulk_columns - blacklisted_columns # return a list of insertable column (without `id`)
columns = Testing.bulk_columns_without_timestamps - blacklisted_columns # return attributes without `id`, `created_at`, `updated_at`

Testing.bulk_insert(columns) do |worker|
  ...
end
```