### PR TITLE
Add ability to handle Oracle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,4 @@ gemspec
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 
+gem 'pry', group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
       tzinfo (~> 1.1)
     arel (6.0.3)
     builder (3.2.2)
+    coderay (1.1.0)
     erubis (2.7.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -53,11 +54,16 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.6.2)
     mini_portile (0.6.2)
     minitest (5.8.1)
-    nokogiri (1.6.6.2)
+    nokogiri (1.6.7.rc3)
       mini_portile (~> 0.6.0)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -86,6 +92,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
+    slop (3.6.0)
     sprockets (3.4.0)
       rack (> 1, < 3)
     sprockets-rails (2.3.3)
@@ -103,6 +110,7 @@ PLATFORMS
 
 DEPENDENCIES
   bulk_insert!
+  pry
   rails (~> 4.2.2)
   sqlite3
 


### PR DESCRIPTION
This adds the ability for the bulk_insert gem to use Oracle. A couple of notes:

1) Added `pry` gem for debugging
2) I had to use a beta version of `nokogiri` on my system. Because of the recent changes in OS X El Capitain, nokogiri was failing to compile. This fixes that.
3) I was unable to add tests for this simply because you have to have Oracle running for it to work, and to my knowledge there's no lightweight Oracle instance that allows for this.