### PR TITLE
Use module ClassMethods instead of class_methods for Rails 4.1 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     bulk_insert (1.1.0)
-      activerecord (~> 4.2.2)
+      activerecord (>= 4.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -103,8 +103,8 @@ PLATFORMS
 
 DEPENDENCIES
   bulk_insert!
-  rails (~> 4.2.2)
+  rails (>= 4.1.0)
   sqlite3
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/lib/bulk_insert.rb
+++ b/lib/bulk_insert.rb
@@ -3,7 +3,7 @@ require 'bulk_insert/worker'
 module BulkInsert
   extend ActiveSupport::Concern
 
-  class_methods do
+  module ClassMethods
     def bulk_insert(*columns, values: nil, set_size:500)
       columns = default_bulk_columns if columns.empty?
       worker = BulkInsert::Worker.new(connection, table_name, columns, set_size)


### PR DESCRIPTION
I noticed in the [last commit](https://github.com/jamis/bulk_insert/commit/8dee79458864f7a559c9e85aee32570d7a9649c1) to `master`, support for Rails 4.1 was added. Unfortunately, `class_methods` for ActiveSupport concerns is only supported in Rails 4.2+.

This PR changes `class_methods` to Ruby's `module ClassMethods` for general support. Also if we could get a minor gem bump, it would be appreciated as well so Rails 4.1 apps can source directly from Rubygems instead of Github.

Thanks for a great library.