### PR TITLE
Allow BulkInsert to be used with ActiveRecord in non-Rails projects.

### DIFF
--- a/lib/bulk_insert/worker.rb
+++ b/lib/bulk_insert/worker.rb
@@ -64,7 +64,7 @@ module BulkInsert
           @columns.zip(row) do |column, value|
             value = @now if value == :__timestamp_placeholder
 
-            if Rails.version >= "5.0.0"
+            if ActiveRecord::VERSION::STRING >= "5.0.0"
               value = @connection.type_cast_from_column(column, value) if column
               values << @connection.quote(value)
             else


### PR DESCRIPTION
Change Worker#save! to check the ActiveRecord version instead of the Rails version when quoting values for insert.

Allows BulkInsert to be used in ActiveRecord projects that do not use Rails. Addresses issue #10 .