### PR TITLE
Fix Rails 5 belongs_to behaviour override

### DIFF
--- a/lib/bulk_insert.rb
+++ b/lib/bulk_insert.rb
@@ -33,4 +33,6 @@ module BulkInsert
   end
 end
 
-ActiveRecord::Base.send :include, BulkInsert
+ActiveSupport.on_load(:active_record) do
+  send(:include, BulkInsert)
+end


### PR DESCRIPTION
The current version breaks new Rails 5 belongs_to behaviour.  
Some explanations [here](https://github.com/plataformatec/devise/commit/c2c74b0) and [here](https://github.com/rails/rails/issues/23589#issuecomment-228207292)