### PR TITLE
Ignore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,28 @@ Book.bulk_insert do |worker|
 end
 ```
 
+### Insert Ignore
+
+By default, when an insert fails the whole batch of inserts fail. The
+_ignore_ option ignores the inserts that would have failed (because of
+duplicate keys or a null in column with a not null constraint) and
+inserts the rest of the batch.
+
+This is not the default because no errors are raised for the bad
+inserts in the batch.
+
+```ruby
+destination_columns = [:title, :author]
+
+# Ignore bad inserts in the batch
+Book.bulk_insert(*destination_columns, ignore: true) do |worker|
+  worker.add(...)
+  worker.add(...)
+  # ...
+end
+```
+
+
 ## License
 
 BulkInsert is released under the MIT license (see MIT-LICENSE) by

--- a/lib/bulk_insert.rb
+++ b/lib/bulk_insert.rb
@@ -4,9 +4,9 @@ module BulkInsert
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def bulk_insert(*columns, values: nil, set_size:500)
+    def bulk_insert(*columns, values: nil, set_size:500, ignore: false)
       columns = default_bulk_columns if columns.empty?
-      worker = BulkInsert::Worker.new(connection, table_name, columns, set_size)
+      worker = BulkInsert::Worker.new(connection, table_name, columns, set_size, ignore)
 
       if values.present?
         transaction do

--- a/lib/bulk_insert/worker.rb
+++ b/lib/bulk_insert/worker.rb
@@ -4,9 +4,11 @@ module BulkInsert
     attr_accessor :set_size
     attr_accessor :after_save_callback
 
-    def initialize(connection, table_name, column_names, set_size=500)
+    def initialize(connection, table_name, column_names, set_size=500, ignore=false)
       @connection = connection
       @set_size = set_size
+      # INSERT IGNORE only fails inserts with duplicate keys or unallowed nulls not the whole set of inserts
+      @ignore = "IGNORE" if ignore
 
       columns = connection.columns(table_name)
       column_map = columns.inject({}) { |h, c| h.update(c.name => c) }
@@ -62,7 +64,7 @@ module BulkInsert
 
     def save!
       if pending?
-        sql = "INSERT INTO #{@table_name} (#{@column_names}) VALUES "
+        sql = "INSERT #{@ignore} INTO #{@table_name} (#{@column_names}) VALUES "
         @now = Time.now
 
         rows = []


### PR DESCRIPTION
When any insert in a batch of inserts fails then the whole batch of inserts fail.  I added an option to do INSERT IGNORE instead.  This only fails the bad inserts and performs the inserts for the rest of the batch.