### PR TITLE
allow an sql suffix to be added to the resulting INSERT SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,13 @@ Book.bulk_insert(*destination_columns, ignore: true) do |worker|
 end
 ```
 
+# Support for ON DUPLICATE KEY UPDATE extension in MySQL
+```ruby
+Book.bulk_insert(:title, on_duplicate_key: { update: 'count = count + 1' }) do |worker|
+  worker.add ["The Chosen"]
+  worker.add ["The Chosen"]
+end
+```
 
 ## License
 

--- a/lib/bulk_insert.rb
+++ b/lib/bulk_insert.rb
@@ -4,9 +4,9 @@ module BulkInsert
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def bulk_insert(*columns, values: nil, set_size:500, ignore: false)
+    def bulk_insert(*columns, values: nil, set_size:500, ignore: false, on_duplicate_key: nil)
       columns = default_bulk_columns if columns.empty?
-      worker = BulkInsert::Worker.new(connection, table_name, columns, set_size, ignore)
+      worker = BulkInsert::Worker.new(connection, table_name, columns, set_size, ignore, on_duplicate_key)
 
       if values.present?
         transaction do


### PR DESCRIPTION
MySQL allows an option ON DUPLICATE KEY UPDATE suffix for INSERT statements. This PR adds an ability to add the logic as string when doing the bulk insert.
```
sql_suffix = ' ON DUPLICATE KEY UPDATE count=count+1'
Book.bulk_insert(sql_suffix: sql_suffix) do |worker|
  book_attrs.each do |attrs|
    worker.add(attrs)
  end
end
```