### PR TITLE
Add before_save_callback option.

### DIFF
--- a/lib/bulk_insert/worker.rb
+++ b/lib/bulk_insert/worker.rb
@@ -2,6 +2,7 @@ module BulkInsert
   class Worker
     attr_reader :connection
     attr_accessor :set_size
+    attr_accessor :before_save_callback
     attr_accessor :after_save_callback
 
     def initialize(connection, table_name, column_names, set_size=500, ignore=false)
@@ -58,6 +59,10 @@ module BulkInsert
       self
     end
 
+    def before_save(&block)
+      @before_save_callback = block
+    end
+
     def after_save(&block)
       @after_save_callback = block
     end
@@ -82,6 +87,8 @@ module BulkInsert
           end
           rows << "(#{values.join(',')})"
         end
+
+        @before_save_callback.(@set) if @before_save_callback
 
         sql << rows.join(",")
         @connection.execute(sql)

--- a/lib/bulk_insert/worker.rb
+++ b/lib/bulk_insert/worker.rb
@@ -18,6 +18,7 @@ module BulkInsert
       @table_name = connection.quote_table_name(table_name)
       @column_names = column_names.map { |name| connection.quote_column_name(name) }.join(",")
 
+      @before_save_callback = nil
       @after_save_callback = nil
 
       @set = []

--- a/lib/bulk_insert/worker.rb
+++ b/lib/bulk_insert/worker.rb
@@ -72,6 +72,8 @@ module BulkInsert
         sql = "INSERT #{@ignore} INTO #{@table_name} (#{@column_names}) VALUES "
         @now = Time.now
 
+        @before_save_callback.(@set) if @before_save_callback
+
         rows = []
         @set.each do |row|
           values = []
@@ -88,10 +90,10 @@ module BulkInsert
           rows << "(#{values.join(',')})"
         end
 
-        @before_save_callback.(@set) if @before_save_callback
-
-        sql << rows.join(",")
-        @connection.execute(sql)
+        if !rows.empty?
+          sql << rows.join(",")
+          @connection.execute(sql)
+        end
 
         @after_save_callback.() if @after_save_callback
 

--- a/test/bulk_insert/worker_test.rb
+++ b/test/bulk_insert/worker_test.rb
@@ -150,5 +150,68 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
 
     assert_equal "hello", @insert.after_save_callback.()
   end
+
+  test "save! calls the before_save handler" do
+    x = 41
+
+    @insert.before_save do
+      x += 1
+    end
+
+    @insert.add ["Yo", 15, false, @now, @now]
+    @insert.add ["Hello", 25, true, @now, @now]
+    @insert.save!
+
+    assert_equal 42, x
+  end
+
+  test "before_save stores a block as a proc" do
+    @insert.before_save do
+      "hello"
+    end
+
+    assert_equal "hello", @insert.before_save_callback.()
+  end
+
+  test "before_save_callback can be set as a proc" do
+    @insert.before_save_callback = -> do
+      "hello"
+    end
+
+    assert_equal "hello", @insert.before_save_callback.()
+  end
+
+  test "before_save can manipulate the set" do
+    @insert.before_save do |set|
+      set.reject!{|row| row[0] == "Yo"}
+    end
+
+    @insert.add ["Yo", 15, false, @now, @now]
+    @insert.add ["Hello", 25, true, @now, @now]
+    @insert.save!
+
+    yo = Testing.find_by(greeting: 'Yo')
+    hello = Testing.find_by(greeting: 'Hello')
+
+    assert_nil yo
+    assert_not_nil hello
+  end
+
+  test "save! doesn't blow up if before_save emptying the set" do
+    @insert.before_save do |set|
+      set.clear
+    end
+
+    @insert.add ["Yo", 15, false, @now, @now]
+    @insert.add ["Hello", 25, true, @now, @now]
+    @insert.save!
+
+    yo = Testing.find_by(greeting: 'Yo')
+    hello = Testing.find_by(greeting: 'Hello')
+
+    assert_nil yo
+    assert_nil hello
+  end
+
 end
 


### PR DESCRIPTION
I had a use case where I needed to examine/manipulate values from the current set before saving. For this purpose I've added a before_save_callback option. Maybe you find this useful.