### PR TITLE
Support SQLite ignore syntax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bulk_insert (1.4.0)
+    bulk_insert (1.4.1)
       activerecord (>= 4.1.0)
 
 GEM

--- a/lib/bulk_insert/version.rb
+++ b/lib/bulk_insert/version.rb
@@ -1,7 +1,7 @@
 module BulkInsert
   MAJOR = 1
   MINOR = 4
-  TINY  = 0
+  TINY  = 1
 
   VERSION = [MAJOR, MINOR, TINY].join(".")
 end

--- a/lib/bulk_insert/worker.rb
+++ b/lib/bulk_insert/worker.rb
@@ -113,7 +113,16 @@ module BulkInsert
     end
 
     def insert_sql_statement
-      insert_ignore = 'IGNORE' if (adapter_name == 'MySQL') && ignore
+      insert_ignore = if ignore
+        if adapter_name == "MySQL"
+          'IGNORE'
+        elsif adapter_name.match(/sqlite.*/)
+          'OR IGNORE'
+        else
+          '' # Not supported
+        end
+      end
+
       "INSERT #{insert_ignore} INTO #{@table_name} (#{@column_names}) VALUES "
     end
 

--- a/lib/bulk_insert/worker.rb
+++ b/lib/bulk_insert/worker.rb
@@ -116,7 +116,7 @@ module BulkInsert
       insert_ignore = if ignore
         if adapter_name == "MySQL"
           'IGNORE'
-        elsif adapter_name.match(/sqlite.*/)
+        elsif adapter_name.match(/sqlite.*/i)
           'OR IGNORE'
         else
           '' # Not supported

--- a/test/bulk_insert/worker_test.rb
+++ b/test/bulk_insert/worker_test.rb
@@ -253,7 +253,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     assert_equal pgsql_worker.compose_insert_query, "INSERT  INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,'f',NULL,NULL,'chartreuse') ON CONFLICT DO NOTHING"
   end
 
-  test "adapter dependent sqlite3 methods" do
+  test "adapter dependent sqlite3 methods (with lowercase adapter name)" do
     sqlite_worker = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
@@ -261,6 +261,19 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
       500, # batch size
       true) # ignore
     sqlite_worker.adapter_name = 'sqlite3'
+    sqlite_worker.add ["Yo", 15, false, nil, nil]
+
+    assert_equal sqlite_worker.compose_insert_query, "INSERT OR IGNORE INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,'f',NULL,NULL,'chartreuse')"
+  end
+
+  test "adapter dependent sqlite3 methods (with stylecase adapter name)" do
+    sqlite_worker = BulkInsert::Worker.new(
+      Testing.connection,
+      Testing.table_name,
+      %w(greeting age happy created_at updated_at color),
+      500, # batch size
+      true) # ignore
+    sqlite_worker.adapter_name = 'SQLite'
     sqlite_worker.add ["Yo", 15, false, nil, nil]
 
     assert_equal sqlite_worker.compose_insert_query, "INSERT OR IGNORE INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,'f',NULL,NULL,'chartreuse')"

--- a/test/bulk_insert/worker_test.rb
+++ b/test/bulk_insert/worker_test.rb
@@ -251,6 +251,18 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     pgsql_worker.add ["Yo", 15, false, nil, nil]
 
     assert_equal pgsql_worker.compose_insert_query, "INSERT  INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,'f',NULL,NULL,'chartreuse') ON CONFLICT DO NOTHING"
+  end
 
+  test "adapter dependent sqlite3 methods" do
+    sqlite_worker = BulkInsert::Worker.new(
+      Testing.connection,
+      Testing.table_name,
+      %w(greeting age happy created_at updated_at color),
+      500, # batch size
+      true) # ignore
+    sqlite_worker.adapter_name = 'sqlite3'
+    sqlite_worker.add ["Yo", 15, false, nil, nil]
+
+    assert_equal sqlite_worker.compose_insert_query, "INSERT OR IGNORE INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,'f',NULL,NULL,'chartreuse')"
   end
 end


### PR DESCRIPTION
This expands the condition that adds "IGNORE" to the SQL query when `ignore: true` is set and `adapter_name` is "MySQL" so that it also adds "OR IGNORE" to the query when `adapter_name` matches `/sqlite.*/`.