### PR TITLE
Allow Users to Update Duplicate Mysql Rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,24 @@ Book.bulk_insert(*destination_columns, ignore: true) do |worker|
 end
 ```
 
+### Update Duplicates (MySQL)
+
+If you don't want to ignore duplicate rows but instead want to update them
+then you can use the _update_duplicates_ option. Set this option to true
+and when a duplicate row is found the row will be updated with your new
+values. Default value for this option is false.
+
+```ruby
+destination_columns = [:title, :author]
+
+# Update duplicate rows
+Book.bulk_insert(*destination_columns, update_duplicates: true) do |worker|
+  worker.add(...)
+  worker.add(...)
+  # ...
+end
+```
+
 
 ## License
 

--- a/lib/bulk_insert.rb
+++ b/lib/bulk_insert.rb
@@ -4,9 +4,9 @@ module BulkInsert
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def bulk_insert(*columns, values: nil, set_size:500, ignore: false)
+    def bulk_insert(*columns, values: nil, set_size:500, ignore: false, update_duplicates: false)
       columns = default_bulk_columns if columns.empty?
-      worker = BulkInsert::Worker.new(connection, table_name, columns, set_size, ignore)
+      worker = BulkInsert::Worker.new(connection, table_name, columns, set_size, ignore, update_duplicates)
 
       if values.present?
         transaction do

--- a/lib/bulk_insert/worker.rb
+++ b/lib/bulk_insert/worker.rb
@@ -5,15 +5,16 @@ module BulkInsert
     attr_accessor :before_save_callback
     attr_accessor :after_save_callback
     attr_accessor :adapter_name
-    attr_reader :ignore
+    attr_reader :ignore, :update_duplicates
 
-    def initialize(connection, table_name, column_names, set_size=500, ignore=false)
+    def initialize(connection, table_name, column_names, set_size=500, ignore=false, update_duplicates=false)
       @connection = connection
       @set_size = set_size
 
       @adapter_name = connection.adapter_name
       # INSERT IGNORE only fails inserts with duplicate keys or unallowed nulls not the whole set of inserts
       @ignore = ignore
+      @update_duplicates = update_duplicates
 
       columns = connection.columns(table_name)
       column_map = columns.inject({}) { |h, c| h.update(c.name => c) }
@@ -85,7 +86,7 @@ module BulkInsert
 
     def compose_insert_query
       sql = insert_sql_statement
-      @now = Time.now    
+      @now = Time.now
       rows = []
 
       @set.each do |row|
@@ -113,8 +114,12 @@ module BulkInsert
     end
 
     def insert_sql_statement
-      insert_ignore = if ignore
-        if adapter_name == "MySQL"
+      "INSERT #{insert_ignore} INTO #{@table_name} (#{@column_names}) VALUES "
+    end
+
+    def insert_ignore
+      if ignore
+        if adapter_name =~ /^mysql/i
           'IGNORE'
         elsif adapter_name.match(/sqlite.*/i)
           'OR IGNORE'
@@ -122,12 +127,19 @@ module BulkInsert
           '' # Not supported
         end
       end
-
-      "INSERT #{insert_ignore} INTO #{@table_name} (#{@column_names}) VALUES "
     end
 
     def on_conflict_statement
-      (adapter_name == 'PostgreSQL' && ignore ) ? ' ON CONFLICT DO NOTHING' : ''
+      if (adapter_name == 'PostgreSQL' && ignore )
+        ' ON CONFLICT DO NOTHING'
+      elsif adapter_name =~ /^mysql/i && update_duplicates
+        update_values = @columns.map do |column|
+          "#{column.name}=VALUES(#{column.name})"
+        end.join(', ')
+        ' ON DUPLICATE KEY UPDATE ' + update_values
+      else
+        ''
+      end
     end
   end
 end


### PR DESCRIPTION
This branch allows users to choose to update duplicate mysql rows rather than ignore them or throw an error. I also added the change from @varyform's [PR](https://github.com/jamis/bulk_insert/pull/26) to allow support for MySql2 adapters.