### PR TITLE
Postgres Option to Return Primary Keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,3 @@ gemspec
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 
-group :test do
-  gem "pg", "< 1.0"
-end
-

--- a/README.md
+++ b/README.md
@@ -167,6 +167,24 @@ Book.bulk_insert(*destination_columns, update_duplicates: true) do |worker|
 end
 ```
 
+# Return Primary Keys (PostgreSQL, PostGIS)
+
+If you want the worker to store primary keys of inserted records, then you can
+use the _return_primary_keys_ option. The worker will store a `result_sets`
+array of `ActiveRecord::Result` objects. Each `ActiveRecord::Result` object
+will contain the primary keys of a batch of inserted records.
+
+```ruby
+worker = Book.bulk_insert(*destination_columns, return_primary_keys: true) do
+|worker|
+  worker.add(...)
+  worker.add(...)
+  # ...
+end
+
+worker.result_sets
+```
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Book.bulk_insert(*destination_columns, update_duplicates: true) do |worker|
 end
 ```
 
-# Return Primary Keys (PostgreSQL, PostGIS)
+### Return Primary Keys (PostgreSQL, PostGIS)
 
 If you want the worker to store primary keys of inserted records, then you can
 use the _return_primary_keys_ option. The worker will store a `result_sets`

--- a/test/bulk_insert/worker_test.rb
+++ b/test/bulk_insert/worker_test.rb
@@ -123,22 +123,13 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
   end
 
   test "save! does not add to result sets when not returning primary keys" do
-    worker = BulkInsert::Worker.new(
-      Testing.connection,
-      Testing.table_name,
-      'id',
-      %w(greeting age happy created_at updated_at color),
-      500,
-      false,
-      false,
-      false
-    )
-    worker.add greeting: "first"
-    worker.add greeting: "second"
-    worker.save!
+    @insert.add greeting: "first"
+    @insert.add greeting: "second"
+    @insert.save!
 
-    assert_equal 0, worker.result_sets.count
+    assert_equal 0, @insert.result_sets.count
   end
+
 
   test "save! adds to result sets when returning primary keys" do
     worker = BulkInsert::Worker.new(
@@ -151,64 +142,23 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
       false,
       true
     )
+
+    assert_no_difference -> { worker.result_sets.count } do
+      worker.save!
+    end
+
     worker.add greeting: "first"
     worker.add greeting: "second"
     worker.save!
     assert_equal 1, worker.result_sets.count
-    assert_equal 2, worker.result_sets.map(&:to_a).flatten.count
 
     worker.add greeting: "third"
     worker.add greeting: "fourth"
     worker.save!
     assert_equal 2, worker.result_sets.count
-    assert_equal 4, worker.result_sets.map(&:to_a).flatten.count
   end
 
-  test "save! does not change worker result sets if there are no pending rows" do
-    worker = BulkInsert::Worker.new(
-      Testing.connection,
-      Testing.table_name,
-      'id',
-      %w(greeting age happy created_at updated_at color),
-      500,
-      false,
-      false,
-      true
-    )
-    assert_no_difference -> { worker.result_sets.count } do
-      worker.save!
-    end
-  end
-
-  test "results in the same order as the records appear in the insert statement" do
-    worker = BulkInsert::Worker.new(
-      Testing.connection,
-      Testing.table_name,
-      'id',
-      %w(greeting age happy created_at updated_at color),
-      500,
-      false,
-      false,
-      true
-    )
-
-    attributes_for_insertion = (0..20).map { |i| { age: i } }
-    worker.add_all attributes_for_insertion
-    results = worker.result_sets.map(&:to_a).flatten
-
-    returned_ids = results.map {|result| result.fetch("id").to_i }
-    expected_age_for_id_hash = {}
-    returned_ids.map.with_index do |id, index|
-      expected_age_for_id_hash[id] = index
-    end
-
-    new_saved_records = Testing.find(returned_ids)
-    new_saved_records.each do |record|
-      assert_same(expected_age_for_id_hash[record.id], record.age)
-    end
-  end
-
-  test "initialized with empty result_sets array" do
+  test "initialized with empty result sets array" do
     new_worker = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
@@ -312,7 +262,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
   end
 
   test "adapter dependent default methods" do
-    assert_equal @insert.adapter_name, 'PostgreSQL'
+    assert_equal @insert.adapter_name, 'SQLite'
     assert_equal @insert.insert_sql_statement, "INSERT  INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES "
 
     @insert.add ["Yo", 15, false, nil, nil]
@@ -384,7 +334,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
       500, # batch size
       true, # ignore
       false, # update duplicates
-      true # return primary key
+      true # return primary keys
     )
     pgsql_worker.adapter_name = 'PostgreSQL'
     pgsql_worker.add ["Yo", 15, false, nil, nil]
@@ -401,8 +351,8 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
       500, # batch size
       true, # ignore
       false, # update duplicates
-      true # return primary key
-    ) # ignore
+      true # return primary keys
+    )
     pgsql_worker.adapter_name = 'PostGIS'
     pgsql_worker.add ["Yo", 15, false, nil, nil]
 

--- a/test/bulk_insert_test.rb
+++ b/test/bulk_insert_test.rb
@@ -37,7 +37,7 @@ class BulkInsertTest < ActiveSupport::TestCase
   test "bulk_insert with array should save the array immediately" do
     assert_difference "Testing.count", 2 do
       Testing.bulk_insert values: [
-        [ "Hello", 15, true, Time.now, Time.now, "green" ],
+        [ "Hello", 15, true, "green" ],
         { greeting: "Hey", age: 20, happy: false }
       ]
     end

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -1,16 +1,25 @@
+# SQLite version 3.x
+#   gem install sqlite3
+#
+#   Ensure the SQLite 3 gem is defined in your Gemfile
+#   gem 'sqlite3'
+#
 default: &default
-  adapter: postgresql
+  adapter: sqlite3
   pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: bulk_insert_development
+  database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: bulk_insert_test
+  database: db/test.sqlite3
 
+production:
+  <<: *default
+  database: db/production.sqlite3

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -13,9 +13,6 @@
 
 ActiveRecord::Schema.define(version: 20151028194232) do
 
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
   create_table "testings", force: :cascade do |t|
     t.string   "greeting"
     t.integer  "age"


### PR DESCRIPTION
PostgreSQL has a `RETURNING` clause that allows `INSERT` statements to return primary keys of inserted records.

These changes allow the bulk insert worker to store primary keys of inserted records if the option to return primary keys is given and the user uses Postgres or PostGIS.