### PR TITLE
Use #exec_insert over #exec_query because there's no field selections 

### DIFF
--- a/lib/bulk_insert/worker.rb
+++ b/lib/bulk_insert/worker.rb
@@ -89,8 +89,11 @@ module BulkInsert
 
     def execute_query
       if query = compose_insert_query
-        result_set = @connection.exec_query(query)
-        @result_sets.push(result_set) if @return_primary_keys
+        if @return_primary_keys
+          @result_sets.push(@connection.exec_query(query))
+        else
+          @connection.exec_insert(query, 'SQL', [])
+        end
       end
     end
 


### PR DESCRIPTION
## What's up?

Hi there, 

Thanks for the gem! It's awesome. While I was trying it, I got an error on calling `worker.save!`. 
```sh
NoMethodError: undefined method `fields' for nil:NilClass
	from /Users/saw/.gem/ruby/2.3.6/gems/activerecord-3.2.22.9/lib/active_record/connection_adapters/mysql2_adapter.rb:219:in `exec_query'
	from (irb):2
	from /Users/saw/.gem/ruby/2.3.6/gems/railties-3.2.22.9/lib/rails/commands/console.rb:47:in `start'
	from /Users/saw/.gem/ruby/2.3.6/gems/railties-3.2.22.9/lib/rails/commands/console.rb:8:in `start'
	from /Users/saw/.gem/ruby/2.3.6/gems/railties-3.2.22.9/lib/rails/commands.rb:41:in `<top (required)>'
	from script/rails:6:in `require'
	from script/rails:6:in `<main>'
```

## Investigation

It seems that the basic skeleton code of `Connection#exec_query` expects a result set that has field selections. However, since we're doing a bulk insert, it doesn't seem like this will work. 

```ruby
def exec_query(sql, name = 'SQL', binds = [])
  result = execute(sql, name)
  ActiveRecord::Result.new(result.fields, result.to_a)
end
```
However, there is an `Connection#exec_insert` method that does not expect return results. 

I suspect `exec_query` is used because of `return_primary_keys` where we call a `SELECT` after the insert. 

## What this does 
- Use `exec_query` when there primary keys are required 
- Use `exec_insert` otherwise