### PR TITLE
Allow to update duplicates on conflict in PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,19 +149,26 @@ Book.bulk_insert(*destination_columns, ignore: true) do |worker|
 end
 ```
 
-### Update Duplicates (MySQL)
+### Update Duplicates (MySQL, PostgreSQL)
 
 If you don't want to ignore duplicate rows but instead want to update them
 then you can use the _update_duplicates_ option. Set this option to true
-and when a duplicate row is found the row will be updated with your new
-values. Default value for this option is false.
+(MySQL) or list unique column names (PostgreSQL) and when a duplicate row
+is found the row will be updated with your new values.
+Default value for this option is false.
 
 ```ruby
 destination_columns = [:title, :author]
 
-# Update duplicate rows
+# Update duplicate rows (MySQL)
 Book.bulk_insert(*destination_columns, update_duplicates: true) do |worker|
   worker.add(...)
+  worker.add(...)
+  # ...
+end
+
+# Update duplicate rows (PostgreSQL)
+Book.bulk_insert(*destination_columns, update_duplicates: %w[title]) do |worker|
   worker.add(...)
   # ...
 end

--- a/test/bulk_insert/worker_test.rb
+++ b/test/bulk_insert/worker_test.rb
@@ -332,14 +332,14 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
       'id',
       %w(greeting age happy created_at updated_at color),
       500, # batch size
-      true, # ignore
-      false, # update duplicates
+      false, # ignore
+      %w(greeting age happy), # update duplicates
       true # return primary keys
     )
     pgsql_worker.adapter_name = 'PostgreSQL'
     pgsql_worker.add ["Yo", 15, false, nil, nil]
 
-    assert_equal pgsql_worker.compose_insert_query, "INSERT  INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,0,NULL,NULL,'chartreuse') ON CONFLICT DO NOTHING RETURNING id"
+    assert_equal pgsql_worker.compose_insert_query, "INSERT  INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,0,NULL,NULL,'chartreuse') ON CONFLICT(greeting, age, happy) DO UPDATE SET greeting=EXCLUDED.greeting, age=EXCLUDED.age, happy=EXCLUDED.happy, created_at=EXCLUDED.created_at, updated_at=EXCLUDED.updated_at, color=EXCLUDED.color RETURNING id"
   end
 
   test "adapter dependent PostGIS methods" do

--- a/test/bulk_insert/worker_test.rb
+++ b/test/bulk_insert/worker_test.rb
@@ -332,6 +332,23 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
       'id',
       %w(greeting age happy created_at updated_at color),
       500, # batch size
+      true, # ignore
+      false, # update duplicates
+      true # return primary keys
+    )
+    pgsql_worker.adapter_name = 'PostgreSQL'
+    pgsql_worker.add ["Yo", 15, false, nil, nil]
+
+    assert_equal pgsql_worker.compose_insert_query, "INSERT  INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,0,NULL,NULL,'chartreuse') ON CONFLICT DO NOTHING RETURNING id"
+  end
+
+  test "adapter dependent postgresql methods (with update_duplicates)" do
+    pgsql_worker = BulkInsert::Worker.new(
+      Testing.connection,
+      Testing.table_name,
+      'id',
+      %w(greeting age happy created_at updated_at color),
+      500, # batch size
       false, # ignore
       %w(greeting age happy), # update duplicates
       true # return primary keys


### PR DESCRIPTION
It adds support for PostgreSQL 9.5+ `ON CONFLICT DO UPDATE` (
https://wiki.postgresql.org/wiki/What%27s_new_in_PostgreSQL_9.5#INSERT_..._ON_CONFLICT_DO_NOTHING.2FUPDATE_.28.22UPSERT.22.29).

It has been implemented as suggested in https://github.com/jamis/bulk_insert/issues/34#issuecomment-401179377.

However, in a hindsight I feel that these things (ignore, update_duplicates, etc) make this simple gem a bit too bloated. You should probably do standard stuff with a gem and use... custom queries for all the others (I ended up with custom script for my use case eventually: https://gist.github.com/sobstel/1b022e17f2f2bb276e766f7fea974b17).

Feel free to merge it if you disagree ;-)

