### PR TITLE
use double-quote for column-name in update duplicates psql

### DIFF
--- a/lib/bulk_insert/worker.rb
+++ b/lib/bulk_insert/worker.rb
@@ -155,7 +155,7 @@ module BulkInsert
         ' ON CONFLICT DO NOTHING'
       elsif is_postgres && update_duplicates
         update_values = @columns.map do |column|
-          "#{column.name}=EXCLUDED.#{column.name}"
+          "\"#{column.name}\"=EXCLUDED.\"#{column.name}\""
         end.join(', ')
         ' ON CONFLICT(' + update_duplicates.join(', ') + ') DO UPDATE SET ' + update_values
       elsif adapter_name =~ /^mysql/i && update_duplicates

--- a/test/bulk_insert/worker_test.rb
+++ b/test/bulk_insert/worker_test.rb
@@ -356,7 +356,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     pgsql_worker.adapter_name = 'PostgreSQL'
     pgsql_worker.add ["Yo", 15, false, nil, nil]
 
-    assert_equal pgsql_worker.compose_insert_query, "INSERT  INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,0,NULL,NULL,'chartreuse') ON CONFLICT(greeting, age, happy) DO UPDATE SET greeting=EXCLUDED.greeting, age=EXCLUDED.age, happy=EXCLUDED.happy, created_at=EXCLUDED.created_at, updated_at=EXCLUDED.updated_at, color=EXCLUDED.color RETURNING id"
+    assert_equal pgsql_worker.compose_insert_query, "INSERT  INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,0,NULL,NULL,'chartreuse') ON CONFLICT(greeting, age, happy) DO UPDATE SET \"greeting\"=EXCLUDED.\"greeting\", \"age\"=EXCLUDED.\"age\", \"happy\"=EXCLUDED.\"happy\", \"created_at\"=EXCLUDED.\"created_at\", \"updated_at\"=EXCLUDED.\"updated_at\", \"color\"=EXCLUDED.\"color\" RETURNING id"
   end
 
   test "adapter dependent PostGIS methods" do


### PR DESCRIPTION
**Problem**: PostgreSQL supports uppercase in column names, but `Worker` has a bug with `ON CONFLICT` condition. When column name in uppercase or contains uppercase letter, we get error like `excluded.title does not exist` (original column name is `Title`).

**Reason**: All identifiers (including column names) that are not double-quoted are folded to lower case in PostgreSQL.

**Solution**: Column names must to be double-quoted.