### PR TITLE
Drop support for ruby < 2.4 (#57)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: ruby
 rvm:
-  - 2.2
-  - 2.3
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
+matrix:
+  allow_failures:
+    - rvm: 2.7
 script: bundle exec rake

--- a/bulk_insert.gemspec
+++ b/bulk_insert.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
+  s.required_ruby_version = ">= 2.4.0"
   s.add_dependency "activerecord", ">= 3.2.0"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
Closes #57 

Ruby 2.4 has recently reached its EOL.
All previous versions can be safely considered unsupported

- [x] Update CI
- [x] Update .gemspec