### PR TITLE
Worker options ignore: false and update_duplicates: false cause an error when using postgresql_adapter.

### DIFF
--- a/lib/bulk_insert/statement_adapters/postgresql_adapter.rb
+++ b/lib/bulk_insert/statement_adapters/postgresql_adapter.rb
@@ -15,6 +15,8 @@ module BulkInsert
             "#{column.name}=EXCLUDED.#{column.name}"
           end.join(', ')
           ' ON CONFLICT(' + update_duplicates.join(', ') + ') DO UPDATE SET ' + update_values
+        else
+          ''
         end
       end
 


### PR DESCRIPTION
`PostgreSQLAdapter#on_conflict_statement` returns `nil` when both options are false, causing an error when this `nil` is appended to the SQL string.

Test included in the commit. Standalone script to reproduce the problem:

```ruby
require 'active_record'
require 'bulk_insert'

ActiveRecord::Base.logger = Logger.new(STDOUT)
ActiveRecord::Base.establish_connection(
  adapter: 'postgresql',
  database: 'problem',
)
unless ActiveRecord::Base.connection.table_exists?(:tests)
  ActiveRecord::Base.connection.create_table :tests do |t|
    t.text :body
  end
end

class Test < ActiveRecord::Base
end

Test.bulk_insert do |worker|
  %w[a b c d e].each do |body|
    worker.add(body: body)
  end
end
```