### PR TITLE
Replace 'type_cast_from_column' to support Rails 6.1

### DIFF
--- a/lib/bulk_insert/worker.rb
+++ b/lib/bulk_insert/worker.rb
@@ -109,7 +109,10 @@ module BulkInsert
           value = @now if value == :__timestamp_placeholder
 
           if ActiveRecord::VERSION::STRING >= "5.0.0"
-            value = @connection.type_cast_from_column(column, value) if column
+            if column
+              type = @connection.lookup_cast_type_from_column(column)
+              value = type.serialize(value)
+            end
             values << @connection.quote(value)
           else
             values << @connection.quote(value, column)


### PR DESCRIPTION
Passing a column to the active_record method `type_cast` is deprecated and will be removed in Rails 6.2. The `type_cast_from_column` method was also removed as part of Rails 6.1 in [this PR](https://github.com/rails/rails/pull/39106). In the short term we can manually call `lookup_cast_type_from_column` and serialize our values with the returned type.


This resolves errors that look like the following, which occur when using `bulk_insert` and active_record `6.1.X`, such as https://github.com/jamis/bulk_insert/issues/67:
```
undefined method `type_cast_from_column'
```