### PR TITLE
Drop ruby 2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: ruby
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
+
+matrix:
+  allow_failures:
+    rmv: 2.7 # Need to migrate to bundler >= 2
+
 script: bundle exec rake

--- a/bulk_insert.gemspec
+++ b/bulk_insert.gemspec
@@ -14,6 +14,10 @@ Gem::Specification.new do |s|
   s.description = "Faster inserts! Insert N records in a single statement."
   s.license     = "MIT"
 
+  # ruby 2.2 reached EOL in 2018
+  # https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/
+  s.required_ruby_version = '>= 2.3.0'
+
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 


### PR DESCRIPTION
As a part of the preparation of a new major release of this gem, we can stop the support for the library not likely to be used anymore.

This PR drops the support for ruby 2.2 which reached EOL in June 2018
https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/

This also allow to introduce the support for bundler 2: https://bundler.io/blog/2019/01/03/announcing-bundler-2.html
which is a pre-requisite for modern ruby versions