### PR TITLE
Prepare ci mysql testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ arch: amd64
 os: linux
 branch:
   - master
+# https://docs.travis-ci.com/user/database-setup/#mysql
+services:
+  - mysql
 rvm:
   - 2.3
   - 2.4

--- a/Appraisals
+++ b/Appraisals
@@ -1,20 +1,24 @@
 appraise "rails-3" do
+  gem "mysql2"
   gem "rails", "~> 3"
   gem "sqlite3", "~> 1.3.6"
   gem "test-unit", "~> 3.0"
 end
 
 appraise "rails-4" do
+  gem "mysql2"
   gem "rails", "~> 4"
   gem "sqlite3", "~> 1.3.6"
 end
 
 appraise "rails-5" do
+  gem "mysql2"
   gem "rails", "~> 5"
   gem "sqlite3"
 end
 
 appraise "rails-6" do
+  gem "mysql2"
   gem "rails", "~> 6"
   gem "sqlite3"
 end

--- a/gemfiles/rails_3.gemfile
+++ b/gemfiles/rails_3.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "minitest"
 gem "rails", "~> 3"
 gem "sqlite3", "~> 1.3.6"
+gem "mysql2"
 gem "test-unit", "~> 3.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "minitest"
 gem "rails", "~> 4"
 gem "sqlite3", "~> 1.3.6"
+gem "mysql2"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "minitest"
 gem "rails", "~> 5"
 gem "sqlite3"
+gem "mysql2"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "minitest"
 gem "rails", "~> 6"
 gem "sqlite3"
+gem "mysql2"
 
 gemspec path: "../"


### PR DESCRIPTION
Since most of the issues reported relate to mysql2 adapter, this pr prepares the execution of the unit test against mysql in the ci.
This first change will address only travis infrastructure and gem dependencies.