### PR TITLE
Fix ci mysql tests using connection mocks

### DIFF
--- a/test/bulk_insert/worker_test.rb
+++ b/test/bulk_insert/worker_test.rb
@@ -1,7 +1,10 @@
 require 'minitest/mock'
 require 'test_helper'
+require 'connection_mocks'
 
 class BulkInsertWorkerTest < ActiveSupport::TestCase
+  include ConnectionMocks
+
   setup do
     @insert = BulkInsert::Worker.new(
       Testing.connection,
@@ -290,7 +293,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
       mysql_worker.add ["Yo", 15, false, nil, nil]
 
       assert_statement_adapter mysql_worker, 'BulkInsert::StatementAdapters::MySQLAdapter'
-      assert_equal mysql_worker.compose_insert_query, "INSERT IGNORE INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,0,NULL,NULL,'chartreuse')"
+      assert_equal mysql_worker.compose_insert_query, "INSERT IGNORE INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,FALSE,NULL,NULL,'chartreuse')"
     end
   end
 
@@ -312,7 +315,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
       mysql_worker.add ["Yo", 15, false, nil, nil]
 
       assert_statement_adapter mysql_worker, 'BulkInsert::StatementAdapters::MySQLAdapter'
-      assert_equal mysql_worker.compose_insert_query, "INSERT IGNORE INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,0,NULL,NULL,'chartreuse') ON DUPLICATE KEY UPDATE `greeting`=VALUES(`greeting`), `age`=VALUES(`age`), `happy`=VALUES(`happy`), `created_at`=VALUES(`created_at`), `updated_at`=VALUES(`updated_at`), `color`=VALUES(`color`)"
+      assert_equal mysql_worker.compose_insert_query, "INSERT IGNORE INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,FALSE,NULL,NULL,'chartreuse') ON DUPLICATE KEY UPDATE `greeting`=VALUES(`greeting`), `age`=VALUES(`age`), `happy`=VALUES(`happy`), `created_at`=VALUES(`created_at`), `updated_at`=VALUES(`updated_at`), `color`=VALUES(`color`)"
     end
   end
 
@@ -332,8 +335,8 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
       mysql_worker.add ["Yo", 15, false, nil, nil]
 
       assert_statement_adapter mysql_worker, 'BulkInsert::StatementAdapters::MySQLAdapter'
-      assert_equal mysql_worker.compose_insert_query, "INSERT IGNORE INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,0,NULL,NULL,'chartreuse')"
-      end
+      assert_equal mysql_worker.compose_insert_query, "INSERT IGNORE INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,FALSE,NULL,NULL,'chartreuse')"
+    end
   end
 
   test "adapter dependent postgresql methods" do
@@ -469,44 +472,11 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
       mysql_worker.add ["Yo", 15, false, nil, nil]
 
       assert_statement_adapter mysql_worker, 'BulkInsert::StatementAdapters::MySQLAdapter'
-      assert_equal mysql_worker.compose_insert_query, "INSERT  INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,0,NULL,NULL,'chartreuse') ON DUPLICATE KEY UPDATE `greeting`=VALUES(`greeting`), `age`=VALUES(`age`), `happy`=VALUES(`happy`), `created_at`=VALUES(`created_at`), `updated_at`=VALUES(`updated_at`), `color`=VALUES(`color`)"
+      assert_equal mysql_worker.compose_insert_query, "INSERT  INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,FALSE,NULL,NULL,'chartreuse') ON DUPLICATE KEY UPDATE `greeting`=VALUES(`greeting`), `age`=VALUES(`age`), `happy`=VALUES(`happy`), `created_at`=VALUES(`created_at`), `updated_at`=VALUES(`updated_at`), `color`=VALUES(`color`)"
     end
   end
 
   def assert_statement_adapter(worker, adapter_name)
     assert_equal worker.instance_variable_get(:@statement_adapter).class.to_s, adapter_name
-  end
-
-  DOUBLE_QUOTE_PROC =  Proc.new do |value, *_column|
-    return value unless value.is_a? String
-    "\"#{value}\""
-  end
-
-  BACKTICK_QUOTE_PROC =  Proc.new do |value, *_column|
-    return value unless value.is_a? String
-    '`' + value + '`'
-  end
-
-  def stub_connection_if_needed(connection, adapter_name)
-    raise "You need to provide a block" unless block_given?
-    if connection.adapter_name == adapter_name
-      yield
-    else
-      connection.stub :adapter_name, adapter_name do
-        if adapter_name =~ /^mysql/i
-          connection.stub :quote_table_name, BACKTICK_QUOTE_PROC do
-            connection.stub :quote_column_name, BACKTICK_QUOTE_PROC do
-              yield
-            end
-          end
-        else
-          connection.stub :quote_table_name, DOUBLE_QUOTE_PROC do
-            connection.stub :quote_column_name, DOUBLE_QUOTE_PROC do
-              yield
-            end
-          end
-        end
-      end
-    end
   end
 end

--- a/test/connection_mocks.rb
+++ b/test/connection_mocks.rb
@@ -1,0 +1,104 @@
+module ConnectionMocks
+  DOUBLE_QUOTE_PROC =  Proc.new do |value, *_column|
+    return value unless value.is_a? String
+    "\"#{value}\""
+  end
+
+  BACKTICK_QUOTE_PROC =  Proc.new do |value, *_column|
+    return value unless value.is_a? String
+    '`' + value + '`'
+  end
+
+  MYSQL_VALUE_QUOTE_PROC =  Proc.new do |value, *_column|
+    case value
+    when String
+      "'" + value + "'"
+    when TrueClass
+      'TRUE'
+    when FalseClass
+      'FALSE'
+    when NilClass
+      'NULL'
+    else
+      value
+    end
+  end
+
+  DEFAULT_VALUE_QUOTE_PROC =  Proc.new do |value, *_column|
+    case value
+    when String
+      "'" + value + "'"
+    when TrueClass
+      1
+    when FalseClass
+      0
+    when NilClass
+      'NULL'
+    else
+      value
+    end
+  end
+
+  ColumnMock = Struct.new(:name, :default)
+  COLUMNS_MOCK_PROC =  Proc.new do |*_table_name|
+    %w(id greeting age happy created_at updated_at color).zip(
+      [nil, nil, nil, nil, nil, nil, "chartreuse"]
+    ).map do |column_name, default|
+      ColumnMock.new(column_name, default)
+    end
+  end
+
+  MockTypeSerialize = Struct.new(:column) do
+    def serialize(value); value; end
+  end
+  CAST_COLUMN_MOCK_PROC = Proc.new do |column|
+    MockTypeSerialize.new(column)
+  end
+
+  def stub_connection_if_needed(connection, adapter_name)
+    raise "You need to provide a block" unless block_given?
+    if connection.adapter_name == adapter_name
+      yield
+    else
+      common_mocks(connection, adapter_name) do
+        if adapter_name =~ /^mysql/i
+          mock_mysql_connection(connection, adapter_name) do
+            yield
+          end
+        else
+          connection.stub :quote_table_name, DOUBLE_QUOTE_PROC do
+            connection.stub :quote_column_name, DOUBLE_QUOTE_PROC do
+              connection.stub :quote, DEFAULT_VALUE_QUOTE_PROC do
+                yield
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def common_mocks(connection, adapter_name)
+    connection.stub :adapter_name, adapter_name do
+      connection.stub :columns, COLUMNS_MOCK_PROC do
+        if ActiveRecord::VERSION::STRING >= "5.0.0"
+          connection.stub :lookup_cast_type_from_column, CAST_COLUMN_MOCK_PROC do
+            yield
+          end
+        else
+          yield
+        end
+      end
+    end
+  end
+
+  def mock_mysql_connection(connection, adapter_name)
+    connection.stub :quote_table_name, BACKTICK_QUOTE_PROC do
+      connection.stub :quote_column_name, BACKTICK_QUOTE_PROC do
+        connection.stub :quote, MYSQL_VALUE_QUOTE_PROC do
+          yield
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduce a more structured stubbing for connections not being used by the real database.

Currently our CI covers;
* sqlite3
* mysql

After fixing all the remaining inconsistent tests, we may consider to extend the testing to other connections (e.g. postgresql)