### PR TITLE
Restore rails < 5 mysql support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - env: DB_ADAPTER=mysql
   include:
     - rvm: 2.2
       gemfile: gemfiles/rails_3.gemfile

--- a/FIXME.md
+++ b/FIXME.md
@@ -1,0 +1,92 @@
+bin/rails test /home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:336
+..F
+Failure:
+BulkInsertWorkerTest#test_adapter_dependent_Mysql2Spatial_methods [/home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:332]:
+--- expected
++++ actual
+@@ -1 +1 @@
+-"INSERT IGNORE INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,FALSE,NULL,NULL,'chartreuse')"
++"INSERT IGNORE INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,0,NULL,NULL,'chartreuse')"
+bin/rails test /home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:317
+F
+Failure:
+BulkInsertWorkerTest#test_adapter_dependent_mysql_methods [/home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:292]:
+--- expected
++++ actual
+@@ -1 +1 @@
+-"INSERT IGNORE INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,FALSE,NULL,NULL,'chartreuse')"
++"INSERT IGNORE INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,0,NULL,NULL,'chartreuse')"
+bin/rails test /home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:273
+F
+Failure:
+BulkInsertWorkerTest#test_adapter_dependent_mysql_methods_work_for_mysql2 [/home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:313]:
+--- expected
++++ actual
+@@ -1 +1 @@
+-"INSERT IGNORE INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,FALSE,NULL,NULL,'chartreuse') ON DUPLICATE KEY UPDATE `greeting`=VALUES(`greeting`), `age`=VALUES(`age`), `happy`=VALUES(`happy`), `created_at`=VALUES(`created_at`), `updated_at`=VALUES(`updated_at`), `color`=VALUES(`color`)"
++"INSERT IGNORE INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,0,NULL,NULL,'chartreuse') ON DUPLICATE KEY UPDATE `greeting`=VALUES(`greeting`), `age`=VALUES(`age`), `happy`=VALUES(`happy`), `created_at`=VALUES(`created_at`), `updated_at`=VALUES(`updated_at`), `color`=VALUES(`color`)"
+bin/rails test /home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:296
+..F
+Failure:
+BulkInsertWorkerTest#test_adapter_dependent_sqlite3_methods_(with_lowercase_adapter_name) [/home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:427]:
+--- expected
++++ actual
+@@ -1 +1 @@
+-"INSERT OR IGNORE INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,FALSE,NULL,NULL,'chartreuse')"
++"INSERT OR IGNORE INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,0,NULL,NULL,'chartreuse')"
+bin/rails test /home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:414
+......F
+Failure:
+BulkInsertWorkerTest#test_adapter_dependent_default_methods [/home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:266]:
+Expected: "Mysql2"
+  Actual: "SQLite"
+bin/rails test /home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:265
+F
+Failure:
+BulkInsertWorkerTest#test_adapter_dependent_postgresql_methods_(with_update_duplicates) [/home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:391]:
+--- expected
++++ actual
+@@ -1 +1 @@
+-"INSERT  INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,FALSE,NULL,NULL,'chartreuse') ON CONFLICT(greeting, age, happy) DO UPDATE SET greeting=EXCLUDED.greeting, age=EXCLUDED.age, happy=EXCLUDED.happy, created_at=EXCLUDED.created_at, updated_at=EXCLUDED.updated_at, color=EXCLUDED.color RETURNING id"
++"INSERT  INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,0,NULL,NULL,'chartreuse') ON CONFLICT(greeting, age, happy) DO UPDATE SET greeting=EXCLUDED.greeting, age=EXCLUDED.age, happy=EXCLUDED.happy, created_at=EXCLUDED.created_at, updated_at=EXCLUDED.updated_at, color=EXCLUDED.color RETURNING id"
+bin/rails test /home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:376
+F
+Failure:
+BulkInsertWorkerTest#test_adapter_dependent_PostGIS_methods [/home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:410]:
+--- expected
++++ actual
+@@ -1 +1 @@
+-"INSERT  INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,FALSE,NULL,NULL,'chartreuse') ON CONFLICT DO NOTHING RETURNING id"
++"INSERT  INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,0,NULL,NULL,'chartreuse') ON CONFLICT DO NOTHING RETURNING id"
+bin/rails test /home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:395
+.F
+Failure:
+BulkInsertWorkerTest#test_adapter_dependent_postgresql_methods_(no_ignore,_no_update_duplicates) [/home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:372]:
+--- expected
++++ actual
+@@ -1 +1 @@
+-"INSERT  INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,FALSE,NULL,NULL,'chartreuse') RETURNING id"
++"INSERT  INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,0,NULL,NULL,'chartreuse') RETURNING id"
+bin/rails test /home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:356
+.F
+Failure:
+BulkInsertWorkerTest#test_add_should_default_timestamp_columns_to_current_time [/home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:40]:
+Expected Sun, 07 Feb 2021 22:06:47 UTC +00:00 to be >= 2021-02-07 22:06:47 +0000.
+bin/rails test /home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:33
+....F
+Failure:
+BulkInsertWorkerTest#test_adapter_dependent_sqlite3_methods_(with_stylecase_adapter_name) [/home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:444]:
+--- expected
++++ actual
+@@ -1 +1 @@
+-"INSERT OR IGNORE INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,FALSE,NULL,NULL,'chartreuse')"
++"INSERT OR IGNORE INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,0,NULL,NULL,'chartreuse')"
+bin/rails test /home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:431
+....F
+Failure:
+BulkInsertWorkerTest#test_mysql_adapter_can_update_duplicates [/home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:462]:
+--- expected
++++ actual
+@@ -1 +1 @@
+-"INSERT  INTO `testings` (`greeting`,`age`,`happy`,`created_at`,`updated_at`,`color`) VALUES ('Yo',15,FALSE,NULL,NULL,'chartreuse') ON DUPLICATE KEY UPDATE `greeting`=VALUES(`greeting`), `age`=VALUES(`age`), `happy`=VALUES(`happy`), `created_at`=VALUES(`created_at`), `updated_at`=VALUES(`updated_at`), `color`=VALUES(`color`)"
++"INSERT  INTO \"testings\" (\"greeting\",\"age\",\"happy\",\"created_at\",\"updated_at\",\"color\") VALUES ('Yo',15,0,NULL,NULL,'chartreuse') ON DUPLICATE KEY UPDATE `greeting`=VALUES(`greeting`), `age`=VALUES(`age`), `happy`=VALUES(`happy`), `created_at`=VALUES(`created_at`), `updated_at`=VALUES(`updated_at`), `color`=VALUES(`color`)"

--- a/test/bulk_insert/worker_test.rb
+++ b/test/bulk_insert/worker_test.rb
@@ -148,14 +148,8 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     )
 
     # return_primary_keys is not supported for mysql and rails < 5
-    if ActiveRecord::VERSION::STRING < "5.0.0"
-      # in rails 3 test chaining the conditions with && raises the following exception
-      # NoMethodError: undefined method `<=' for #<Regexp:0x0000000003a23ed0>
-      if worker.adapter_name =~ /^mysql/i
-        # skip is not supported in the minitest version used for testing rails 3
-        return
-      end
-    end
+    # skip is not supported in the minitest version used for testing rails 3
+    return if ActiveRecord::VERSION::STRING < "5.0.0" && worker.adapter_name =~ /^mysql/i
 
     assert_no_difference -> { worker.result_sets.count } do
       worker.save!

--- a/test/bulk_insert/worker_test.rb
+++ b/test/bulk_insert/worker_test.rb
@@ -147,6 +147,16 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
       true
     )
 
+    # return_primary_keys is not supported for mysql and rails < 5
+    if ActiveRecord::VERSION::STRING < "5.0.0"
+      # in rails 3 test chaining the conditions with && raises the following exception
+      # NoMethodError: undefined method `<=' for #<Regexp:0x0000000003a23ed0>
+      if worker.adapter_name =~ /^mysql/i
+        # skip is not supported in the minitest version used for testing rails 3
+        return
+      end
+    end
+
     assert_no_difference -> { worker.result_sets.count } do
       worker.save!
     end

--- a/test/bulk_insert_test.rb
+++ b/test/bulk_insert_test.rb
@@ -33,14 +33,9 @@ class BulkInsertTest < ActiveSupport::TestCase
 
     # return_primary_keys is not supported for mysql and rails < 5
     # this test ensures that the case is covered in the CI and handled as expected
-    if ActiveRecord::VERSION::STRING < "5.0.0"
-      # in rails 3 test chaining the conditions with && raises the following exception
-      # NoMethodError: undefined method `<=' for #<Regexp:0x0000000003a23ed0>
-      if worker.adapter_name =~ /^mysql/i
-        assert_raise(ArgumentError, /BulkInsert does not support @return_primary_keys for mysql and rails < 5/) do
-          worker.save!
-        end
-      end
+    if ActiveRecord::VERSION::STRING < "5.0.0" && worker.adapter_name =~ /^mysql/i
+      error = assert_raise(ArgumentError) { worker.save! }
+      assert_equal error.message, "BulkInsert does not support @return_primary_keys for mysql and rails < 5"
     else
       worker.save!
       assert_equal 1, worker.result_sets.count


### PR DESCRIPTION
In #77 I was able to reproduce in unit tests the issue describe in #41:

```
  1) Error:
BulkInsertWorkerTest#test_explicit_nil_should_override_defaults:
NoMethodError: undefined method `fields' for nil:NilClass
    /home/travis/.rvm/gems/ruby-2.3.8/gems/activerecord-4.2.11.3/lib/active_record/connection_adapters/mysql2_adapter.rb:222:in `exec_query'
    /home/travis/build/jamis/bulk_insert/lib/bulk_insert/worker.rb:96:in `execute_query'
    /home/travis/build/jamis/bulk_insert/lib/bulk_insert/worker.rb:86:in `save!'
    /home/travis/build/jamis/bulk_insert/test/bulk_insert/worker_test.rb:67:in `block in <class:BulkInsertWorkerTest>'
```

It looks like https://github.com/jamis/bulk_insert/compare/v1.6.0...v1.7.0 broke the compatibility for mysql adapter on rails < 5.

This pr fixes the issue and restore the support for mysql rails < 5.
It also enforce a strict test suite for mysql adapter (prepared in #74 #75 #76 )  to ensure that similar regressions won't happen in the future.