### PR TITLE
Raise KeyError when specifying non existent column

### DIFF
--- a/lib/bulk_insert/worker.rb
+++ b/lib/bulk_insert/worker.rb
@@ -25,7 +25,7 @@ module BulkInsert
       column_map = columns.inject({}) { |h, c| h.update(c.name => c) }
 
       @primary_key = primary_key
-      @columns = column_names.map { |name| column_map[name.to_s] }
+      @columns = column_names.map { |name| column_map.fetch(name.to_s) }
       @table_name = connection.quote_table_name(table_name)
       @column_names = column_names.map { |name| connection.quote_column_name(name) }.join(",")
 

--- a/test/bulk_insert/worker_test.rb
+++ b/test/bulk_insert/worker_test.rb
@@ -269,6 +269,17 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     assert_nil hello
   end
 
+  test "meaningful error is raised when specifying non existent columns" do
+    assert_raises(KeyError) {
+      BulkInsert::Worker.new(
+        Testing.connection,
+        Testing.table_name,
+        'id',
+        %w(no_such_column)
+      )
+    }
+  end
+
   test "adapter dependent SQLite methods" do
     connection = Testing.connection
     stub_connection_if_needed(connection, 'SQLite') do


### PR DESCRIPTION
We have a setup where we occasionally try to bulk import from a database with a schema that is out of sync with the target.  If the source database has columns that do not exist on the target  a more meaningful error from `bulk_import` would help us debug.

This change causes the code to short circuit with a `KeyError` if a non existent column is specified in the initializer.

Error before:
```
Error:
BulkInsertWorkerTest#test_meaningul_error_is_presented_if_specifying_non_existant_columns:
NoMethodError: undefined method `name' for nil:NilClass
    .../bulk_insert/lib/bulk_insert/worker.rb:52:in `block in add'
    .../bulk_insert/lib/bulk_insert/worker.rb:51:in `map'
    .../bulk_insert/lib/bulk_insert/worker.rb:51:in `with_index'
    .../bulk_insert/lib/bulk_insert/worker.rb:51:in `add'
    .../bulk_insert/test/bulk_insert/worker_test.rb:280:in `block in <class:BulkInsertWorkerTest>'
```

Error after:
```
Error:
BulkInsertWorkerTest#test_meaningul_error_is_presented_if_specifying_non_existant_columns:
KeyError: key not found: "no_such_column"
    .../bulk_insert/lib/bulk_insert/worker.rb:28:in `fetch'
    .../bulk_insert/lib/bulk_insert/worker.rb:28:in `block in initialize'
    .../bulk_insert/lib/bulk_insert/worker.rb:28:in `map'
    .../bulk_insert/lib/bulk_insert/worker.rb:28:in `initialize'
    .../bulk_insert/test/bulk_insert/worker_test.rb:273:in `new'
    .../bulk_insert/test/bulk_insert/worker_test.rb:273:in `block in <class:BulkInsertWorkerTest>
```